### PR TITLE
Fix reference to dev/go in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -486,7 +486,7 @@ Alternatively you can roll your own Reloaded workflow quite easily, but you will
 
 (defn reset []
   (stop)
-  (refresh :after 'user/go))
+  (refresh :after 'dev/go))
 ----
 
 


### PR DESCRIPTION
We want to call the `go` defined in the `dev` ns, right?