### PR TITLE
respect java.lang.AutoCloseable

### DIFF
--- a/src/juxt/clip/impl/core.cljc
+++ b/src/juxt/clip/impl/core.cljc
@@ -218,8 +218,8 @@
     stop-code
     (evaluator stop-code {'this inst})
     #?@(:clj
-         [(isa? (class inst) java.io.Closeable)
-          (.close ^java.io.Closeable inst)])))
+        [(instance? java.lang.AutoCloseable inst)
+         (.close ^java.lang.AutoCloseable inst)])))
 
 (defn component-chain
   [system]
@@ -235,7 +235,7 @@
   (defn StatefulThing
     []
     (reify
-      java.io.Closeable
+      java.lang.AutoCloseable
       (close [this]
         (println  "Closing a stateful thing"))))
   (def system2

--- a/test/juxt/clip/core_test.cljc
+++ b/test/juxt/clip/core_test.cljc
@@ -115,7 +115,7 @@
 
   (let [closed? (atom false)
         auto-closable (reify
-                        java.io.Closeable
+                        java.lang.AutoCloseable
                         (close [this]
                           (reset! closed? true)))]
     (clip/stop {:components


### PR DESCRIPTION
the README suggests `AutoCloseable` is respected, but currently is not.

reproduction:
```
dev=> (require '[juxt.clip.core :as clip])
nil

dev=> (def config
 #_=>   {:components
 #_=>    {:a {:start #(reify java.lang.AutoCloseable
 #_=>                   (close [_]
 #_=>                     (println "close <java.lang.AutoCloseable>")))}
 #_=>     :b {:start #(reify java.io.Closeable
 #_=>                   (close [_]
 #_=>                     (println "close <java.io.Closeable>")))}}})
 #_=>

dev=> (clip/stop config (clip/start config))
close <java.io.Closeable>
{:a nil, :b nil}
```

makes the following improvements:
- switch `java.io.Closeable` to superinterface, `java.lang.AutoCloseable`.
- switch from `(isa? (class x) C)` to [more idiomatic](https://stuartsierra.com/2015/05/02/clojure-donts-isa) `(instance? C x)`.